### PR TITLE
Strerror & GetMidiEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,8 @@ func process(nframes uint32) int {
  - `int jack_set_process_callback(client, callback, arg)`
  - `jack_port_t jack_port_register(client, name, type, flags, buffer_size)`
  - `void* jack_port_get_buffer(port, nframes)`
+ - `int jack_midi_event_get(event, port_buffer, event_index)`
+ - `void jack_midi_clear_buffer(void* port_buffer)`
+ - `int jack_midi_event_write(port_buffer, time, data, data_size)`
 
 See [Official Jack API](http://jackaudio.org/api/jack_8h.html) for detailed documentation on each of these functions.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func process(nframes uint32) int {
  - `jack_port_t jack_port_register(client, name, type, flags, buffer_size)`
  - `void* jack_port_get_buffer(port, nframes)`
  - `int jack_midi_event_get(event, port_buffer, event_index)`
- - `void jack_midi_clear_buffer(void* port_buffer)`
+ - `void jack_midi_clear_buffer(port_buffer)`
  - `int jack_midi_event_write(port_buffer, time, data, data_size)`
 
 See [Official Jack API](http://jackaudio.org/api/jack_8h.html) for detailed documentation on each of these functions.

--- a/errors.go
+++ b/errors.go
@@ -5,42 +5,42 @@ import "C"
 import "fmt"
 
 func Strerror(status int) error {
-    if 0 == status {
-        return nil
-    }
+	if 0 == status {
+		return nil
+	}
 
-    var msg string
-    switch status {
-    case Failure:
-        msg = "overall operation failed"
-    case InvalidOption:
-        msg = "the operation contained an invalid or unsupported option"
-    case NameNotUnique:
-        msg = "the desired client name was not unique"
-    case ServerStarted:
-        msg = "The JACK server was started as a result of this operation. Otherwise, it was running already. In either case the caller is now connected to jackd, so there is no race condition. When the server shuts down, the client will find out."
-    case ServerFailed:
-        msg = "unable to connect to the JACK server"
-    case ServerError:
-        msg = "communication error with the JACK server"
-    case NoSuchClient:
-        msg = "requested client does not exist"
-    case LoadFailure:
-        msg = "unable to load internal client"
-    case InitFailure:
-        msg = "unable to initialize client"
-    case ShmFailure:
-        msg = "unable to access shared memory"
-    case VersionError:
-        msg = "client's protocol version does not match"
-    case BackendError:
-        msg = "backend error"
-    case ClientZombie:
-        msg = "client zombie"
-    case C.EEXIST:
-        msg = "the connection is already made"
-    default:
-        msg = fmt.Sprintf("unknown error %d", status)
-    }
-    return fmt.Errorf(msg)
+	var msg string
+	switch status {
+	case Failure:
+		msg = "overall operation failed"
+	case InvalidOption:
+		msg = "the operation contained an invalid or unsupported option"
+	case NameNotUnique:
+		msg = "the desired client name was not unique"
+	case ServerStarted:
+		msg = "The JACK server was started as a result of this operation. Otherwise, it was running already. In either case the caller is now connected to jackd, so there is no race condition. When the server shuts down, the client will find out."
+	case ServerFailed:
+		msg = "unable to connect to the JACK server"
+	case ServerError:
+		msg = "communication error with the JACK server"
+	case NoSuchClient:
+		msg = "requested client does not exist"
+	case LoadFailure:
+		msg = "unable to load internal client"
+	case InitFailure:
+		msg = "unable to initialize client"
+	case ShmFailure:
+		msg = "unable to access shared memory"
+	case VersionError:
+		msg = "client's protocol version does not match"
+	case BackendError:
+		msg = "backend error"
+	case ClientZombie:
+		msg = "client zombie"
+	case C.EEXIST:
+		msg = "the connection is already made"
+	default:
+		msg = fmt.Sprintf("unknown error %d", status)
+	}
+	return fmt.Errorf(msg)
 }

--- a/errors.go
+++ b/errors.go
@@ -39,6 +39,10 @@ func Strerror(status int) error {
 		msg = "client zombie"
 	case C.EEXIST:
 		msg = "the connection is already made"
+	case C.ENODATA:
+		msg = "the buffer is empty"
+	case C.ENOBUFS:
+		msg = "there is not enough space in the buffer for the event"
 	default:
 		msg = fmt.Sprintf("unknown error %d", status)
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,46 @@
+package jack
+
+// #include <sys/errno.h>
+import "C"
+import "fmt"
+
+func Strerror(status int) error {
+    if 0 == status {
+        return nil
+    }
+
+    var msg string
+    switch status {
+    case Failure:
+        msg = "overall operation failed"
+    case InvalidOption:
+        msg = "the operation contained an invalid or unsupported option"
+    case NameNotUnique:
+        msg = "the desired client name was not unique"
+    case ServerStarted:
+        msg = "The JACK server was started as a result of this operation. Otherwise, it was running already. In either case the caller is now connected to jackd, so there is no race condition. When the server shuts down, the client will find out."
+    case ServerFailed:
+        msg = "unable to connect to the JACK server"
+    case ServerError:
+        msg = "communication error with the JACK server"
+    case NoSuchClient:
+        msg = "requested client does not exist"
+    case LoadFailure:
+        msg = "unable to load internal client"
+    case InitFailure:
+        msg = "unable to initialize client"
+    case ShmFailure:
+        msg = "unable to access shared memory"
+    case VersionError:
+        msg = "client's protocol version does not match"
+    case BackendError:
+        msg = "backend error"
+    case ClientZombie:
+        msg = "client zombie"
+    case C.EEXIST:
+        msg = "the connection is already made"
+    default:
+        msg = fmt.Sprintf("unknown error %d", status)
+    }
+    return fmt.Errorf(msg)
+}

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,6 +1,5 @@
 build:
-	go build passthrough.go
+	go build passthrough.go midipassthrough.go
 
 run:
 	./passthrough
-

--- a/example/midipassthrough.go
+++ b/example/midipassthrough.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/esqilin/go-jack"
+	"github.com/xthexder/go-jack"
 )
 
 var (

--- a/example/midipassthrough.go
+++ b/example/midipassthrough.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/esqilin/go-jack"
+)
+
+var (
+	portIn, portOut *jack.Port
+	ch              chan string // for printing midi events
+)
+
+func process(nframes uint32) int {
+	events := portIn.GetMidiEvents(nframes)
+	buffer := portOut.MidiClearBuffer(nframes)
+	for _, event := range events {
+		ch <- fmt.Sprintf("%#v", event)
+		portOut.MidiEventWrite(event, buffer)
+	}
+
+	return 0
+}
+
+func shutdown() {
+	os.Exit(0)
+}
+
+func main() {
+	client, status := jack.ClientOpen("Go Midi Passthrough", jack.NoStartServer)
+	if status != 0 {
+		fmt.Println(jack.Strerror(status))
+		return
+	}
+	defer client.Close()
+
+	if code := client.SetProcessCallback(process); code != 0 {
+		fmt.Println("Failed to set process callback: ", jack.Strerror(code))
+		return
+	}
+	client.OnShutdown(shutdown)
+
+	if code := client.Activate(); code != 0 {
+		fmt.Println("Failed to activate client: ", jack.Strerror(code))
+		return
+	}
+
+	portIn = client.PortRegister("midi_in", jack.DEFAULT_MIDI_TYPE, jack.PortIsInput, 0)
+	portOut = client.PortRegister("midi_out", jack.DEFAULT_MIDI_TYPE, jack.PortIsOutput, 0)
+
+	fmt.Println(client.GetName())
+
+	ch = make(chan string, 30)
+	str, more := "", true
+	for more {
+		str, more = <-ch
+		fmt.Printf("Midi Event: %s\n", str)
+	}
+}

--- a/jack.go
+++ b/jack.go
@@ -4,6 +4,7 @@ package jack
 #cgo LDFLAGS: -ljack
 #include <stdlib.h>
 #include <jack/jack.h>
+#include <jack/midiport.h>
 
 extern int goProcess(unsigned int, void *);
 extern int goBufferSize(uint, void *);
@@ -300,6 +301,28 @@ func (port *Port) GetType() string {
 func (port *Port) GetBuffer(nframes uint32) []AudioSample {
 	samples := C.jack_port_get_buffer(port.handler, C.jack_nframes_t(nframes))
 	return (*[1 << 30]AudioSample)(samples)[:nframes:nframes]
+}
+
+type MidiData struct {
+	Time   uint32
+	Buffer []byte
+}
+
+func (port *Port) GetMidiEvents(nframes uint32) []*MidiData {
+	var event C.jack_midi_event_t
+	samples := C.jack_port_get_buffer(port.handler, C.jack_nframes_t(nframes))
+	nEvents := uint32(C.jack_midi_get_event_count(samples))
+	events := make([]*MidiData, nEvents, nEvents)
+	for i := range events {
+		C.jack_midi_event_get(&event, samples, C.uint32_t(i))
+		size := event.size
+		buffer := C.GoBytes(unsafe.Pointer(event.buffer), C.int(size))
+		events[i] = &MidiData{
+			Time:   uint32(event.time),
+			Buffer: buffer,
+		}
+	}
+	return events
 }
 
 func (port *Port) GetConnections() []string {


### PR DESCRIPTION
This is my first pull request on github; after reading the guidelines I realize that I should have created one or two new branches.

I created an extra file with function _Strerror_ for translating JACK status values into Go errors.
Completely unrelated, the second commit adds the function _GetMidiEvents_ which returns a slice of MidiData pointers. Maybe it is too high level, maybe it should come in a separate subpackage because it necessarily imports _jack/midiport.h_.

Thanks for the implementation, I also wrote a wrapper and realized that it became way to high level so I switched my projects to your go-jack.
