### PR TITLE
Add SetErrorFunction and SetInfoFunction for setting custom standard output/error functions

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -10,6 +10,8 @@ type PortRegistrationCallback func(PortId, bool)
 type PortRenameCallback func(PortId, string, string) int
 type PortConnectCallback func(PortId, PortId, bool)
 type ShutdownCallback func()
+type ErrorFunction func(string)
+type InfoFunction func(string)
 
 //export goProcess
 func goProcess(nframes uint, wrapper unsafe.Pointer) int {
@@ -51,4 +53,18 @@ func goPortConnect(aport, bport uint, connect int, wrapper unsafe.Pointer) {
 func goShutdown(wrapper unsafe.Pointer) {
 	callback := (*ShutdownCallback)(wrapper)
 	(*callback)()
+}
+
+//export goErrorFunction
+func goErrorFunction(msg *C.char) {
+	if errorFunction != nil {
+		errorFunction(C.GoString(msg))
+	}
+}
+
+//export goInfoFunction
+func goInfoFunction(msg *C.char) {
+	if infoFunction != nil {
+		infoFunction(C.GoString(msg))
+	}
 }

--- a/jack.go
+++ b/jack.go
@@ -13,9 +13,19 @@ extern void goPortRegistration(jack_port_id_t, int, void *);
 extern void goPortRename(jack_port_id_t, const char *, const char *, void *);
 extern void goPortConnect(jack_port_id_t, jack_port_id_t, int, void *);
 extern void goShutdown(void *);
+extern void goErrorFunction(const char *);
+extern void goInfoFunction(const char *);
 
 jack_client_t* jack_client_open_go(const char * client_name, int options, int * status) {
 	return jack_client_open(client_name, (jack_options_t) options, (jack_status_t *) status);
+}
+
+void jack_set_error_function_go() {
+	jack_set_error_function(goErrorFunction);
+}
+
+void jack_set_info_function_go() {
+	jack_set_info_function(goInfoFunction);
 }
 
 int jack_set_process_callback_go(jack_client_t * client, void * callback) {
@@ -98,6 +108,11 @@ type Client struct {
 
 type AudioSample float32
 
+var (
+	errorFunction ErrorFunction = nil
+	infoFunction  InfoFunction  = nil
+)
+
 func ClientOpen(name string, options int) (*Client, int) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -114,6 +129,16 @@ func ClientOpen(name string, options int) (*Client, int) {
 
 func ClientNameSize() int {
 	return int(C.jack_client_name_size())
+}
+
+func SetErrorFunction(callback ErrorFunction) {
+	errorFunction = callback
+	C.jack_set_error_function_go()
+}
+
+func SetInfoFunction(callback InfoFunction) {
+	infoFunction = callback
+	C.jack_set_info_function_go()
 }
 
 func (client *Client) Activate() int {


### PR DESCRIPTION
These functions call `jack_set_error_function(void(*)(const char *))` and `jack_set_info_function(void(*)(const char *))` respectively.

I'm still very much a beginner at Go, so I'm not sure if it's implemented correctly. I had to store the Go callbacks in variables, so that I could call them from a wrapper Go function, similarly as it is done with the client callbacks. If you happen to know a better way around this, I'll change it.

Usage example:
```go
jack.SetInfoFunction(func(msg string) {
    log.Println("INFO", msg)
})
jack.SetErrorFunction(func(msg string) {
    log.Println("ERROR", msg)
})
```