### PR TITLE
Update callbacks to fix cgo errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ _testmain.go
 *.prof
 
 /example/passthrough
+/example/midipassthrough
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jacob Wirth
+Copyright (c) 2018 Jacob Wirth
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -75,5 +75,7 @@ func process(nframes uint32) int {
  - `int jack_midi_event_get(event, port_buffer, event_index)`
  - `void jack_midi_clear_buffer(port_buffer)`
  - `int jack_midi_event_write(port_buffer, time, data, data_size)`
+ - `void jack_set_error_function(callback)`
+ - `void jack_set_info_function(callback)`
 
 See [Official Jack API](http://jackaudio.org/api/jack_8h.html) for detailed documentation on each of these functions.

--- a/callbacks.go
+++ b/callbacks.go
@@ -3,66 +3,56 @@ package jack
 import "C"
 import "unsafe"
 
-type ProcessCallback func(uint32, interface{}) int
-type processCallbackWithArgs struct {
-	callback ProcessCallback
-	args     interface{}
-}
+type ProcessCallback func(uint32) int
 type BufferSizeCallback func(uint32) int
 type SampleRateCallback func(uint32) int
 type PortRegistrationCallback func(PortId, bool)
-type PortRenameCallback func(PortId, string, string) int
+type PortRenameCallback func(PortId, string, string)
 type PortConnectCallback func(PortId, PortId, bool)
 type ShutdownCallback func()
 type ErrorFunction func(string)
 type InfoFunction func(string)
 
 //export goProcess
-func goProcess(nframes uint, wrapper unsafe.Pointer) int {
-	callback := (*ProcessCallback)(wrapper)
-	return (*callback)(uint32(nframes), nil)
-}
-
-//export goProcessWithArgs
-func goProcessWithArgs(nframes uint, wrapper unsafe.Pointer) int {
-	ret := (*processCallbackWithArgs)(wrapper)
-	return (*ret).callback(uint32(nframes), (*ret).args)
+func goProcess(nframes uint, arg unsafe.Pointer) int {
+	client := (*C.struct__jack_client)(arg)
+	return clientMap[client].processCallback(uint32(nframes))
 }
 
 //export goBufferSize
-func goBufferSize(nframes uint, wrapper unsafe.Pointer) int {
-	callback := (*BufferSizeCallback)(wrapper)
-	return (*callback)(uint32(nframes))
+func goBufferSize(nframes uint, arg unsafe.Pointer) int {
+	client := (*C.struct__jack_client)(arg)
+	return clientMap[client].bufferSizeCallback(uint32(nframes))
 }
 
 //export goSampleRate
-func goSampleRate(nframes uint, wrapper unsafe.Pointer) int {
-	callback := (*SampleRateCallback)(wrapper)
-	return (*callback)(uint32(nframes))
+func goSampleRate(nframes uint, arg unsafe.Pointer) int {
+	client := (*C.struct__jack_client)(arg)
+	return clientMap[client].sampleRateCallback(uint32(nframes))
 }
 
 //export goPortRegistration
-func goPortRegistration(port uint, register int, wrapper unsafe.Pointer) {
-	callback := (*PortRegistrationCallback)(wrapper)
-	(*callback)(PortId(port), register != 0)
+func goPortRegistration(port uint, register int, arg unsafe.Pointer) {
+	client := (*C.struct__jack_client)(arg)
+	clientMap[client].portRegistrationCallback(PortId(port), register != 0)
 }
 
 //export goPortRename
-func goPortRename(port uint, oldName, newName *C.char, wrapper unsafe.Pointer) {
-	callback := (*PortRenameCallback)(wrapper)
-	(*callback)(PortId(port), C.GoString(oldName), C.GoString(newName))
+func goPortRename(port uint, oldName, newName *C.char, arg unsafe.Pointer) {
+	client := (*C.struct__jack_client)(arg)
+	clientMap[client].portRenameCallback(PortId(port), C.GoString(oldName), C.GoString(newName))
 }
 
 //export goPortConnect
-func goPortConnect(aport, bport uint, connect int, wrapper unsafe.Pointer) {
-	callback := (*PortConnectCallback)(wrapper)
-	(*callback)(PortId(aport), PortId(bport), connect != 0)
+func goPortConnect(aport, bport uint, connect int, arg unsafe.Pointer) {
+	client := (*C.struct__jack_client)(arg)
+	clientMap[client].portConnectCallback(PortId(aport), PortId(bport), connect != 0)
 }
 
 //export goShutdown
-func goShutdown(wrapper unsafe.Pointer) {
-	callback := (*ShutdownCallback)(wrapper)
-	(*callback)()
+func goShutdown(arg unsafe.Pointer) {
+	client := (*C.struct__jack_client)(arg)
+	clientMap[client].shutdownCallback()
 }
 
 //export goErrorFunction

--- a/callbacks.go
+++ b/callbacks.go
@@ -3,7 +3,11 @@ package jack
 import "C"
 import "unsafe"
 
-type ProcessCallback func(uint32) int
+type ProcessCallback func(uint32, *interface{}) int
+type processCallbackWithArgs struct {
+	callback ProcessCallback
+	args     *interface{}
+}
 type BufferSizeCallback func(uint32) int
 type SampleRateCallback func(uint32) int
 type PortRegistrationCallback func(PortId, bool)
@@ -14,7 +18,13 @@ type ShutdownCallback func()
 //export goProcess
 func goProcess(nframes uint, wrapper unsafe.Pointer) int {
 	callback := (*ProcessCallback)(wrapper)
-	return (*callback)(uint32(nframes))
+	return (*callback)(uint32(nframes), nil)
+}
+
+//export goProcessWithArgs
+func goProcessWithArgs(nframes uint, wrapper unsafe.Pointer) int {
+	ret := (*processCallbackWithArgs)(wrapper)
+	return (*ret).callback(uint32(nframes), (*ret).args)
 }
 
 //export goBufferSize

--- a/callbacks.go
+++ b/callbacks.go
@@ -10,6 +10,8 @@ type PortRegistrationCallback func(PortId, bool)
 type PortRenameCallback func(PortId, string, string) int
 type PortConnectCallback func(PortId, PortId, bool)
 type ShutdownCallback func()
+type ErrorFunction func(string)
+type InfoFunction func(string)
 
 //export goProcess
 func goProcess(nframes uint, wrapper unsafe.Pointer) int {
@@ -51,4 +53,18 @@ func goPortConnect(aport, bport uint, connect int, wrapper unsafe.Pointer) {
 func goShutdown(wrapper unsafe.Pointer) {
 	callback := (*ShutdownCallback)(wrapper)
 	(*callback)()
+}
+
+//export goErrorFunction
+func goErrorFunction(msg *C.char) {
+	if errorFunction != nil {
+		errorFunction(C.GoString(msg))
+	}
+}
+
+//export goInfoFunction
+func goInfoFunction(msg *C.char) {
+	if infoFunction != nil {
+		infoFunction(C.GoString(msg))
+	}
 }

--- a/callbacks.go
+++ b/callbacks.go
@@ -3,10 +3,10 @@ package jack
 import "C"
 import "unsafe"
 
-type ProcessCallback func(uint32, *interface{}) int
+type ProcessCallback func(uint32, interface{}) int
 type processCallbackWithArgs struct {
 	callback ProcessCallback
-	args     *interface{}
+	args     interface{}
 }
 type BufferSizeCallback func(uint32) int
 type SampleRateCallback func(uint32) int

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,7 @@ package jack
 import "C"
 import "fmt"
 
-func Strerror(status int) error {
+func StrError(status int) error {
 	if 0 == status {
 		return nil
 	}

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,5 +1,6 @@
 build:
-	go build passthrough.go midipassthrough.go
+	go build passthrough.go
+	go build midipassthrough.go
 
 run:
 	./passthrough

--- a/jack.go
+++ b/jack.go
@@ -13,9 +13,19 @@ extern void goPortRegistration(jack_port_id_t, int, void *);
 extern void goPortRename(jack_port_id_t, const char *, const char *, void *);
 extern void goPortConnect(jack_port_id_t, jack_port_id_t, int, void *);
 extern void goShutdown(void *);
+extern void goErrorFunction(const char *);
+extern void goInfoFunction(const char *);
 
 jack_client_t* jack_client_open_go(const char * client_name, int options, int * status) {
 	return jack_client_open(client_name, (jack_options_t) options, (jack_status_t *) status);
+}
+
+void jack_set_error_function_go() {
+	jack_set_error_function(goErrorFunction);
+}
+
+void jack_set_info_function_go() {
+	jack_set_info_function(goInfoFunction);
 }
 
 int jack_set_process_callback_go(jack_client_t * client, void * callback) {
@@ -98,6 +108,11 @@ type Client struct {
 
 type AudioSample float32
 
+var (
+	errorFunction ErrorFunction = nil
+	infoFunction  InfoFunction  = nil
+)
+
 func ClientOpen(name string, options int) (*Client, int) {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -114,6 +129,16 @@ func ClientOpen(name string, options int) (*Client, int) {
 
 func ClientNameSize() int {
 	return int(C.jack_client_name_size())
+}
+
+func SetErrorFunction(callback ErrorFunction) {
+	errorFunction = callback
+	C.jack_set_error_function_go()
+}
+
+func SetInfoFunction(callback InfoFunction) {
+	infoFunction = callback
+	C.jack_set_info_function_go()
 }
 
 func (client *Client) Activate() int {

--- a/jack.go
+++ b/jack.go
@@ -149,7 +149,7 @@ func (client *Client) SetProcessCallback(callback ProcessCallback) int {
 	))
 }
 
-func (client *Client) SetProcessCallbackWithArgs(callback ProcessCallback, args *interface{}) int {
+func (client *Client) SetProcessCallbackWithArgs(callback ProcessCallback, args interface{}) int {
 	client.processCallback = callback
 	return int(C.jack_set_process_callback_with_args_go(
 		client.handler,

--- a/jack.go
+++ b/jack.go
@@ -7,6 +7,7 @@ package jack
 #include <jack/midiport.h>
 
 extern int goProcess(unsigned int, void *);
+extern int goProcessWithArgs(unsigned int, void *);
 extern int goBufferSize(uint, void *);
 extern int goSampleRate(uint, void *);
 extern void goPortRegistration(jack_port_id_t, int, void *);
@@ -20,6 +21,10 @@ jack_client_t* jack_client_open_go(const char * client_name, int options, int * 
 
 int jack_set_process_callback_go(jack_client_t * client, void * callback) {
 	return jack_set_process_callback(client, goProcess, callback);
+}
+
+int jack_set_process_callback_with_args_go(jack_client_t * client, void * callback) {
+	return jack_set_process_callback(client, goProcessWithArgs, callback);
 }
 
 int jack_set_buffer_size_callback_go(jack_client_t * client, void * callback) {
@@ -138,7 +143,21 @@ func (client *Client) GetSampleRate() uint32 {
 
 func (client *Client) SetProcessCallback(callback ProcessCallback) int {
 	client.processCallback = callback
-	return int(C.jack_set_process_callback_go(client.handler, unsafe.Pointer(&client.processCallback)))
+	return int(C.jack_set_process_callback_go(
+		client.handler,
+		unsafe.Pointer(&client.processCallback),
+	))
+}
+
+func (client *Client) SetProcessCallbackWithArgs(callback ProcessCallback, args *interface{}) int {
+	client.processCallback = callback
+	return int(C.jack_set_process_callback_with_args_go(
+		client.handler,
+		unsafe.Pointer(&processCallbackWithArgs{
+			callback: client.processCallback,
+			args:     args,
+		}),
+	))
 }
 
 func (client *Client) SetBufferSizeCallback(callback BufferSizeCallback) int {

--- a/jack.go
+++ b/jack.go
@@ -7,7 +7,6 @@ package jack
 #include <jack/midiport.h>
 
 extern int goProcess(unsigned int, void *);
-extern int goProcessWithArgs(unsigned int, void *);
 extern int goBufferSize(uint, void *);
 extern int goSampleRate(uint, void *);
 extern void goPortRegistration(jack_port_id_t, int, void *);
@@ -21,44 +20,40 @@ jack_client_t* jack_client_open_go(const char * client_name, int options, int * 
 	return jack_client_open(client_name, (jack_options_t) options, (jack_status_t *) status);
 }
 
+int jack_set_process_callback_go(jack_client_t * client) {
+	return jack_set_process_callback(client, goProcess, client);
+}
+
+int jack_set_buffer_size_callback_go(jack_client_t * client) {
+	return jack_set_buffer_size_callback(client, goBufferSize, client);
+}
+
+int jack_set_sample_rate_callback_go(jack_client_t * client) {
+	return jack_set_sample_rate_callback(client, goSampleRate, client);
+}
+
+int jack_set_port_registration_callback_go(jack_client_t * client) {
+	return jack_set_port_registration_callback(client, goPortRegistration, client);
+}
+
+int jack_set_port_rename_callback_go(jack_client_t * client) {
+	return jack_set_port_rename_callback(client, goPortRename, client);
+}
+
+int jack_set_port_connect_callback_go(jack_client_t * client) {
+	return jack_set_port_connect_callback(client, goPortConnect, client);
+}
+
+void jack_on_shutdown_go(jack_client_t * client) {
+	jack_on_shutdown(client, goShutdown, client);
+}
+
 void jack_set_error_function_go() {
 	jack_set_error_function(goErrorFunction);
 }
 
 void jack_set_info_function_go() {
 	jack_set_info_function(goInfoFunction);
-}
-
-int jack_set_process_callback_go(jack_client_t * client, void * callback) {
-	return jack_set_process_callback(client, goProcess, callback);
-}
-
-int jack_set_process_callback_with_args_go(jack_client_t * client, void * callback) {
-	return jack_set_process_callback(client, goProcessWithArgs, callback);
-}
-
-int jack_set_buffer_size_callback_go(jack_client_t * client, void * callback) {
-	return jack_set_buffer_size_callback(client, goBufferSize, callback);
-}
-
-int jack_set_sample_rate_callback_go(jack_client_t * client, void * callback) {
-	return jack_set_sample_rate_callback(client, goSampleRate, callback);
-}
-
-int jack_set_port_registration_callback_go(jack_client_t * client, void * callback) {
-	return jack_set_port_registration_callback(client, goPortRegistration, callback);
-}
-
-int jack_set_port_rename_callback_go(jack_client_t * client, void * callback) {
-	return jack_set_port_rename_callback(client, goPortRename, callback);
-}
-
-int jack_set_port_connect_callback_go(jack_client_t * client, void * callback) {
-	return jack_set_port_connect_callback(client, goPortConnect, callback);
-}
-
-void jack_on_shutdown_go(jack_client_t * client, void * callback) {
-	jack_on_shutdown(client, goShutdown, callback);
 }
 */
 import "C"
@@ -114,6 +109,7 @@ type Client struct {
 type AudioSample float32
 
 var (
+	clientMap     map[*C.struct__jack_client]*Client
 	errorFunction ErrorFunction = nil
 	infoFunction  InfoFunction  = nil
 )
@@ -126,8 +122,12 @@ func ClientOpen(name string, options int) (*Client, int) {
 	cclient := C.jack_client_open_go(cname, C.int(options), &status)
 	var client *Client
 	if cclient != nil {
+		if clientMap == nil {
+			clientMap = make(map[*C.struct__jack_client]*Client)
+		}
 		client = new(Client)
 		client.handler = cclient
+		clientMap[cclient] = client
 	}
 	return client, int(status)
 }
@@ -168,58 +168,49 @@ func (client *Client) GetSampleRate() uint32 {
 
 func (client *Client) SetProcessCallback(callback ProcessCallback) int {
 	client.processCallback = callback
-	return int(C.jack_set_process_callback_go(
-		client.handler,
-		unsafe.Pointer(&client.processCallback),
-	))
-}
-
-func (client *Client) SetProcessCallbackWithArgs(callback ProcessCallback, args interface{}) int {
-	client.processCallback = callback
-	return int(C.jack_set_process_callback_with_args_go(
-		client.handler,
-		unsafe.Pointer(&processCallbackWithArgs{
-			callback: client.processCallback,
-			args:     args,
-		}),
-	))
+	return int(C.jack_set_process_callback_go(client.handler))
 }
 
 func (client *Client) SetBufferSizeCallback(callback BufferSizeCallback) int {
 	client.bufferSizeCallback = callback
-	return int(C.jack_set_buffer_size_callback_go(client.handler, unsafe.Pointer(&client.bufferSizeCallback)))
+	return int(C.jack_set_buffer_size_callback_go(client.handler))
 }
 
 func (client *Client) SetSampleRateCallback(callback SampleRateCallback) int {
 	client.sampleRateCallback = callback
-	return int(C.jack_set_sample_rate_callback_go(client.handler, unsafe.Pointer(&client.sampleRateCallback)))
+	return int(C.jack_set_sample_rate_callback_go(client.handler))
 }
 
 func (client *Client) SetPortRegistrationCallback(callback PortRegistrationCallback) int {
 	client.portRegistrationCallback = callback
-	return int(C.jack_set_port_registration_callback_go(client.handler, unsafe.Pointer(&client.portRegistrationCallback)))
+	return int(C.jack_set_port_registration_callback_go(client.handler))
 }
 
 func (client *Client) SetPortRenameCallback(callback PortRenameCallback) int {
 	client.portRenameCallback = callback
-	return int(C.jack_set_port_rename_callback_go(client.handler, unsafe.Pointer(&client.portRenameCallback)))
+	return int(C.jack_set_port_rename_callback_go(client.handler))
 }
 
 func (client *Client) SetPortConnectCallback(callback PortConnectCallback) int {
 	client.portConnectCallback = callback
-	return int(C.jack_set_port_connect_callback_go(client.handler, unsafe.Pointer(&client.portConnectCallback)))
+	return int(C.jack_set_port_connect_callback_go(client.handler))
 }
 
 func (client *Client) OnShutdown(callback ShutdownCallback) {
 	client.shutdownCallback = callback
-	C.jack_on_shutdown_go(client.handler, unsafe.Pointer(&client.shutdownCallback))
+	C.jack_on_shutdown_go(client.handler)
 }
 
 func (client *Client) Close() int {
-	if client == nil {
+	if client == nil || client.handler == nil {
 		return 0
 	}
-	return int(C.jack_client_close(client.handler))
+	result := int(C.jack_client_close(client.handler))
+	if result == 0 {
+		delete(clientMap, client.handler)
+		client.handler = nil
+	}
+	return result
 }
 
 func (client *Client) PortRegister(portName, portType string, flags, bufferSize uint64) *Port {


### PR DESCRIPTION
Contains https://github.com/xthexder/go-jack/pull/4 and https://github.com/xthexder/go-jack/pull/6 along with some other minor changes.

This fixes both current issues:
 - https://github.com/xthexder/go-jack/issues/3 Callback functions couldn't reference anything but global variables due to a cgo error. This now works
 - https://github.com/xthexder/go-jack/issues/5 The PortRenameCallback is supposed to be a void function.

@angadn I decided not to go the callback argument route.
This fix is backwards compatible and should allow for struct functions and references to local variables, which should be enough for most applications.