### PR TITLE
Reduce buffer size so that this compiles on 32 bit architectures.

### DIFF
--- a/jack.go
+++ b/jack.go
@@ -343,7 +343,7 @@ func (port *Port) GetType() string {
 
 func (port *Port) GetBuffer(nframes uint32) []AudioSample {
 	samples := C.jack_port_get_buffer(port.handler, C.jack_nframes_t(nframes))
-	return (*[1 << 30]AudioSample)(samples)[:nframes:nframes]
+	return (*[(1 << 29) - 1]AudioSample)(samples)[:nframes:nframes]
 }
 
 type MidiData struct {


### PR DESCRIPTION
I tried to compile this on an ARM system with a 32-bit kernel and got a compile-time error due to the size of the array declared in `func (port *Port) GetBuffer(nframes uint32) []AudioSample`.

I reduced the array size from `(*[1 << 30]AudioSample)` to `(*[(1 << 29) - 1]AudioSample)`, which made it compile successfully.

`1 << 29` did not compile, `(1 << 29) - 1` did, so this appears to be exactly the limit on a 32 bit system.
